### PR TITLE
CS-22216 - Skip configuration on standby servers

### DIFF
--- a/lib/facter/openvpnas.rb
+++ b/lib/facter/openvpnas.rb
@@ -1,0 +1,36 @@
+Facter.add(:openvpnas) do
+  setcode do
+    failover_mode = ''
+    failover_state = ''
+    
+    # When failover.mode=ucarp, the openvpnas daemon will not run on the standby server and sacli fails.
+    # Therefore it is necessary to look inside the configuration database directly.
+
+    # Check that SQLite database is used to store the configuration. Only SQLite is supported for now.
+    sqlite_default = Facter::Core::Execution.execute("grep ^config_db=sqlite:///~/db/config.db /usr/local/openvpn_as/etc/as.conf")
+    if sqlite_default != "" then
+      # Read the value of the failover.mode in the configuration database.
+      failover_mode = Facter::Core::Execution.execute("sqlite3 /usr/local/openvpn_as/etc/db/config.db \"select value from config where name == 'failover.mode' limit 1\"")
+      if failover_mode == 'ucarp' then
+        # If failover.mode=ucarp then check the running processes.
+        ucarp = Facter::Core::Execution.execute("pgrep -af ucarp.*ucarp_active.*ucarp_standby | grep -v \"sh -c /usr/bin/pgrep -af\"")
+        if ucarp != "" then
+          # The ucarp process is running.
+          active = Facter::Core::Execution.execute("pgrep -af \"python3 -c from pyovpn.sagent.sagent_entry import ucarp_active\" | grep -v \"sh -c /usr/bin/pgrep -af\"")
+          if active != "" then
+            # The openvpnas process is running.
+              failover_state = 'active'
+          else
+            # The openvpnas process is NOT running.
+            failover_state = 'standby'
+          end
+        else
+          # The failover.mode is set to ucarp but no ucarp process was found.
+          failover_state = 'broken'
+        end
+      end
+    end
+    # Return the failover mode and state variables in a hash.
+    { :failover_mode => failover_mode, :failover_state => failover_state }
+  end
+end

--- a/lib/puppet/provider/openvpnas_config/sacli.rb
+++ b/lib/puppet/provider/openvpnas_config/sacli.rb
@@ -19,7 +19,11 @@ Puppet::Type.type(:openvpnas_config).provide(:sacli) do
 
   def self.instances
     res = []
-    sacli_output = sacli('ConfigQuery')
+    begin
+      sacli_output = sacli('ConfigQuery')
+    rescue
+      sacli_output = "{}"
+    end
     config = JSON.parse(sacli_output)
 
     config.each_pair do |key, value|

--- a/lib/puppet/provider/openvpnas_userprop/sacli.rb
+++ b/lib/puppet/provider/openvpnas_userprop/sacli.rb
@@ -30,7 +30,11 @@ Puppet::Type.type(:openvpnas_userprop).provide(:sacli) do
 
   def self.instances
     res = []
-    sacli_output = sacli('UserPropGet')
+    begin
+      sacli_output = sacli('UserPropGet')
+    rescue
+      sacli_output = "{}"
+    end
     config = JSON.parse(sacli_output)
 
     Puppet.debug(config)

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,8 +2,10 @@ define openvpnas::config (
   String $ensure = present,
   String $value,
 ) {
-  openvpnas_config { $name:
-    ensure => $ensure,
-    value => $value,
+  if ($::openvpnas[failover_mode] == '' ) or ($::openvpnas[failover_mode] == 'ucarp' and $::openvpnas[failover_state] == 'active') {
+    openvpnas_config { $name:
+      ensure => $ensure,
+      value => $value,
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,14 @@ class openvpnas (
   Class['openvpnas::install']
   -> Class['openvpnas::service']
 
-  create_resources(openvpnas::config, $config)
-  create_resources(openvpnas::userprop, $userprop)
+  $failover_mode = $::openvpnas[failover_mode]
+  $failover_state = $::openvpnas[failover_state]
+  notify { "failover_mode is '${failover_mode}' and failover_state is '${failover_state}'.": }
+
+  if ($failover_mode == '') or ($failover_mode == 'ucarp' and $failover_state == 'active') {
+    create_resources(openvpnas::config, $config)
+    create_resources(openvpnas::userprop, $userprop)
+  } else {
+    notify { "Skipping openvpnas_config and openvpnas_userprop resources due to failover_mode(${failover_mode}) and failover_state(${failover_state}).": }
+  }
 }

--- a/manifests/userprop.pp
+++ b/manifests/userprop.pp
@@ -2,8 +2,10 @@ define openvpnas::userprop (
   String $ensure = present,
   String $value,
 ) {
-  openvpnas_userprop { $name:
-    ensure => $ensure,
-    value => $value,
+  if ($::openvpnas[failover_mode] == '' ) or ($::openvpnas[failover_mode] == 'ucarp' and $::openvpnas[failover_state] == 'active') {
+    openvpnas_userprop { $name:
+      ensure => $ensure,
+      value => $value,
+    }
   }
 }


### PR DESCRIPTION
When failover.mode is set to ucarp and the server is in standby mode the openvpnas process is not running and sacli fails to connect to the local socket and the config and userprop resources fail.

It is also necessary to tolerate the sacli failures when reading the config and userprop entries.

A new fact is added as a hash with two keys:
- failover_mode - read directly from the SQLite database
- failover_stage - inferred from by checking the running processes

The config and userprop resources are only applied when there is no failover.mode or the failover.mode is ucarp and the server is in active state.